### PR TITLE
feat(font) no longer loaded remotely

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="stylesheet" href="/src/styles.scss" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" />
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
   </head>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/platform-server": "^18.0.0",
         "@angular/router": "^18.0.0",
+        "@fontsource/lato": "^5.0.21",
         "front-matter": "^4.0.2",
         "marked": "^5.0.2",
         "marked-gfm-heading-id": "^3.1.0",
@@ -5689,6 +5690,11 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@fontsource/lato": {
+      "version": "5.0.21",
+      "resolved": "https://registry.npmjs.org/@fontsource/lato/-/lato-5.0.21.tgz",
+      "integrity": "sha512-UubLwvJO2bKuhWv6+ocx2Bou/pPIT6q7VpYaHIW7ZDaLPQY3uYAhveJg6P7Lvz5HYHyLba8JUc3yP7wvcqA8zQ=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/platform-server": "^18.0.0",
     "@angular/router": "^18.0.0",
+    "@fontsource/lato": "^5.0.21",
     "front-matter": "^4.0.2",
     "marked": "^5.0.2",
     "marked-gfm-heading-id": "^3.1.0",

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -10,9 +10,11 @@ $theme: mat.define-theme(
   )
 );
 
+@import '@fontsource/lato';
+
 body {
   @include mat.all-component-themes($theme);
-  font-family: Roboto, 'Helvetica Neue', sans-serif;
+  font-family: 'Lato', sans-serif;
   margin: 0;
   padding: 30px;
   height: 100%;


### PR DESCRIPTION
# The Pull Request is ready

##Fonts loaded locally 

- [x] fixes idrinth-api-bench/issues#1103
- [ ] all actions are passing
- [x] only fixes a single issue

## Overview

- removed google links from `index.html`
- after trying out several options I found the most straightforward and working option to be using the `fontsource` npm package
- font is temporarily set to `Lato` since anything is better than `Roboto` and is loaded locally

this link `<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />` is for the material icons I left it for now because one of the good benefits of using the Angular Material UI library is that handy icons are provided, if necessary I can remove it 

## Translations-Website

